### PR TITLE
Add a close function

### DIFF
--- a/enso/commands/win_tools.py
+++ b/enso/commands/win_tools.py
@@ -338,9 +338,7 @@ class cWindow:
         win32gui.SetForegroundWindow(self._hwnd)
 
     def Close(self):
-        '''seems to only minimize the window'''
-        win32gui.CloseWindow(self._hwnd)
-##      win32gui.DestroyWindow(self._hwnd) # gives me 'access is denied' error
+        win32gui.SendMessage(self._hwnd, win32con.WM_CLOSE, 0, 0)
 
     def Maximize(self):
         win32gui.ShowWindow(self._hwnd, win32con.SW_MAXIMIZE)
@@ -699,7 +697,13 @@ def cmd_unmaximize(ensoapi):
     """ Unmaximize window if it is maximized """
     cmd_restore(ensoapi)
 
+    
+def cmd_close(ensoapi):
+    """ Close the window currently in the foreground """
+    win = DESK.GetForegroundWindow()
+    win.Close()
 
+    
 class MinimizeAllWindows(CommandObject):
     '''Minimize all visible windows'''
 


### PR DESCRIPTION
I know this project hasn't been touched in several years but I figured this would be a helpful function, I know I use it frequently and it appears that an attempt was previously made to include it.

I am uncertain as to why the win32gui.CloseWindow function didn't work but I was able to acheive the desired result using win32gui.SendMessage.

I recognize that this may not be the best place to include the change, but I figure its quite minor and most people (at least those on Windows that this will affect) will be using this package as opposed to the one on launchpad.