### PR TITLE
fixed cmd_open for win32

### DIFF
--- a/enso/enso/platform/win32/shortcuts/Shortcuts.py
+++ b/enso/enso/platform/win32/shortcuts/Shortcuts.py
@@ -540,6 +540,7 @@ class Shortcuts:
                         continue
                     #print name, ext
                     shortcut_type = SHORTCUT_TYPE_DOCUMENT
+                    shortcut_path = ""
                     if ext.lower() == ".lnk":
                         shortcut_path = os.path.join(dirpath, filename)
                         sl.load(shortcut_path)


### PR DESCRIPTION
on windows, the open command would not work because a variable had not been initialized